### PR TITLE
Event parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ ExternalProject_add(pardibaal
 include_directories(${EXTERNAL_INSTALL_LOCATION}/include)
 link_directories(${EXTERNAL_INSTALL_LOCATION}/lib)
 
+include_directories(include)
+
 add_subdirectory(src/monitaal)
 target_include_directories(MoniTAal INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 

--- a/include/errors.h
+++ b/include/errors.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Peter G. Jensen <root@petergjoel.dk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * File:   errors.h
+ * Author: Peter G. Jensen <root@petergjoel.dk>
+ *
+ * Created on May 10, 2019, 9:46 AM
+ */
+
+#ifndef ERRORS_H
+#define ERRORS_H
+
+#include <sstream>
+
+enum class ReturnValue {
+    SuccessCode = 0,
+    FailedCode = 1,
+    UnknownCode = 2,
+    ErrorCode = 3,
+    ContinueCode = 4
+};
+
+template <typename E>
+constexpr auto to_underlying(E e) noexcept
+{
+    return static_cast<std::underlying_type_t<E>>(e);
+}
+
+struct base_error : public std::exception {
+    std::string _message;
+
+    template<typename ...Args>
+    base_error(Args ...args) {
+        std::stringstream ss;
+        (ss << ... << args);
+        _message = ss.str();
+    }
+
+    const char *what() const noexcept override {
+        return _message.c_str();
+    }
+
+    virtual void print(std::ostream &os) const {
+        os << what() << std::endl;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const base_error &el) {
+        el.print(os);
+        return os;
+    }
+};
+
+#endif /* ERRORS_H */

--- a/src/monitaal/CMakeLists.txt
+++ b/src/monitaal/CMakeLists.txt
@@ -12,14 +12,17 @@ set(HEADER_FILES
         Fixpoint.h
         Parser.h
         types.h
-        Monitor.h)
+        Monitor.h
+        EventParser.h)
 
 add_library(MoniTAal
+        ${HEADER_FILES}
         TA.cpp
         state.cpp
         Fixpoint.cpp
         Parser.cpp
-        Monitor.cpp)
+        Monitor.cpp
+        EventParser.cpp)
 
 target_link_libraries(MoniTAal PRIVATE
         -lpugixml

--- a/src/monitaal/EventParser.cpp
+++ b/src/monitaal/EventParser.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright Thomas M. Grosen 
+ * Created on 11/01/2022
+ */
+
+/*
+ * This file is part of MoniTAal
+ *
+ * MoniTAal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoniTAal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MoniTAal. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "EventParser.h"
+#include "TA.h"
+#include "errors.h"
+
+#include <stdio.h>
+#include <string>
+#include <istream>
+#include <iostream>
+#include <locale>
+
+namespace monitaal {
+
+    void read_seperator(std::istream* stream) {
+        char c;
+        *stream >> std::ws;
+        if (not (*stream >> c && c == '@'))
+            throw base_error("Expected a @ separator at ", stream->tellg(), " but got \"", stream->peek(), "\"");
+        return;
+    }
+
+    concrete_time_t read_concrete_time(std::istream* stream) {
+        concrete_time_t time;
+        *stream >> time;
+        return time;
+    }
+
+    interval_t read_interval(std::istream* stream) {
+        int lower, upper;
+        char c;
+
+        if ( *stream >> std::ws >> c && c == '[' &&
+             *stream >> lower &&
+             *stream >> std::ws >> c && c == ',' &&
+             *stream >> upper &&
+             *stream >> std::ws >> c && c == ']')
+            return std::pair(lower, upper);
+        else {
+            throw base_error("Error parsing interval input at ", stream->tellg(), " but got \"", stream->peek(), "\"");
+        }
+    }
+
+    std::string read_observation(std::istream* stream) {
+        std::string observation = "";
+        char c;
+        
+        *stream >> std::ws;
+
+        c = stream->peek();
+        while (c != ' ' && c != '\t' && c != '\n' && c != '@') {
+            observation += stream->get();
+            c = stream->peek();
+        }
+
+        if (observation.length() == 0)
+            throw base_error("Expected a label string not containing whitespace or @ at ", stream->tellg(), " but got \"", stream->peek(), "\"");
+
+        return observation;
+    }
+
+    std::vector<concrete_input> EventParser::parse_concrete_input(std::istream* stream) {
+        char separator;
+        std::string observation;
+        concrete_time_t time;
+
+        std::vector<concrete_input> events;
+
+        *stream >> std::ws;
+        while (not stream->eof()) {
+            read_seperator(stream);
+            time = read_concrete_time(stream);
+            observation = read_observation(stream);
+
+            events.emplace_back(time, observation);
+
+            *stream >> std::ws;
+        }
+
+        return events;
+    }
+
+    std::vector<interval_input> EventParser::parse_interval_input(std::istream* stream) {
+        std::string observation;
+        interval_t time;
+
+        std::vector<interval_input> events;
+
+        *stream >> std::ws;
+        while (not stream->eof()) {
+            read_seperator(stream);
+            time = read_interval(stream);
+            observation = read_observation(stream);
+
+            events.emplace_back(time, observation);
+            
+            *stream >> std::ws;
+        }
+
+        return events;
+    }
+
+}

--- a/src/monitaal/EventParser.h
+++ b/src/monitaal/EventParser.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright Thomas M. Grosen 
+ * Created on 11/01/2024
+ */
+
+/*
+ * This file is part of MoniTAal
+ *
+ * MoniTAal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoniTAal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MoniTAal. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MONITAAL_EVENT_PARSER_H
+#define MONITAAL_EVENT_PARSER_H
+
+#include "TA.h"
+#include "Monitor.h"
+#include "types.h"
+#include "errors.h"
+
+#include <fstream>
+
+
+/** EVENT PARSER
+ *  Parse events (time points and labels) separated by '@' symbols.
+ *
+ *  Parses either concrete or interval times (never both), by calling the specific parsing function.
+ *  Concrete means time points are singular decimals.
+ *  Interval means time is bounded by an integer lower and upper bound.
+ *
+ *  Whitespace is ignored (space, tab, newline). 
+ *  - Whitespace cannot be included in labels.
+ *  - Whitespace is NOT required to separate any elements.
+ *
+ *  Approximate grammar:
+ *
+ *      EventList := Event 
+ *                 | EventList Event
+ *
+ *      Event := '@' Time Label
+ *
+ *      Time := Interval
+ *            | ConcreteTime
+ *
+ *      Interval := '[' INTEGER ',' INTEGER ']'
+ *
+ *      ConcreteTime := DECIMAL
+ *
+ *      Label := * A string that does not include whitespace or '@' *
+ */
+
+namespace monitaal {
+
+    class EventParser {
+public:
+        static std::vector<concrete_input> parse_concrete_input(std::istream* stream);
+
+        static std::vector<interval_input> parse_interval_input(std::istream* stream);
+    };
+
+}
+
+#endif //MONITAAL_EVENT_PARSER_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,13 +4,16 @@ include_directories (${TEST_SOURCE_DIR}/src
 
 add_definitions (-DBOOST_TEST_DYN_LINK)
 
-add_executable(Monitor_test         Monitor_test.cpp)
+add_executable(Monitor_test          Monitor_test.cpp)
 add_executable(Presentation_examples Presentation_examples.cpp)
+add_executable(EventParserTest       EventParserTest.cpp)
 
 target_link_libraries(Monitor_test         ${Boost_LIBRARIES} MoniTAal)
 target_link_libraries(Presentation_examples ${Boost_LIBRARIES} MoniTAal)
+target_link_libraries(EventParserTest ${Boost_LIBRARIES} MoniTAal)
 
 add_test(NAME Monitor_test COMMAND Monitor_test)
 add_test(NAME Presentation_examples COMMAND Presentation_examples)
+add_test(NAME EventParserTest COMMAND EventParserTest)
 
 add_subdirectory(models)

--- a/test/EventParserTest.cpp
+++ b/test/EventParserTest.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright Thomas M. Grosen 
+ * Created on 11/01/2024
+ */
+
+/*
+ * This file is part of monitaal
+ *
+ * monitaal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * monitaal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with monitaal. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE MONITAAL
+
+#include "monitaal/EventParser.h"
+
+#include <boost/test/unit_test.hpp>
+#include <sstream>
+
+using namespace monitaal;
+
+BOOST_AUTO_TEST_CASE(interval_parsing_test1) {
+    std::stringstream stream("@[0, 10] \ta\n@[5, 10] b@[10, 10] a\n@[20, 25] b @[25, 30] a\n\n", std::ios_base::in);
+
+    std::vector<interval_input> input;
+
+    input = EventParser::parse_interval_input(&stream);
+
+    BOOST_CHECK(input.size() == 5);
+}
+
+BOOST_AUTO_TEST_CASE(concrete_parsing_test1) {
+    std::stringstream stream("@1 a\n@2 b@3 a\n@4b @5 a\n@6.2 a\n", std::ios_base::in);
+
+    std::vector<concrete_input> input;
+
+    input = EventParser::parse_concrete_input(&stream);
+
+    BOOST_CHECK(input.size() == 6);
+}

--- a/test/Presentation_examples.cpp
+++ b/test/Presentation_examples.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(presentation_interval) {
 
     std::vector<interval_input> word2 = {
             interval_input({0, 10}, "a"),
-            interval_input({30, 40}, "c")};
+            interval_input({31, 40}, "c")};
 
     Interval_monitor monitor(pos, neg);
 


### PR DESCRIPTION
Add a simple event parser to parse either interval events or concrete time events.

Format example:
@1.2 a
@10 b @30.6 c
@50.1 a

or


@[1, 3] a
@[10,20] b @[30,40] c
@[50,50] a